### PR TITLE
Fix stacked borrows violation(s)

### DIFF
--- a/src/pretty/exponent.rs
+++ b/src/pretty/exponent.rs
@@ -14,11 +14,11 @@ pub unsafe fn write_exponent3(mut k: isize, mut result: *mut u8) -> usize {
     if k >= 100 {
         *result = b'0' + (k / 100) as u8;
         k %= 100;
-        let d = DIGIT_TABLE.get_unchecked(k as usize * 2);
+        let d = DIGIT_TABLE.as_ptr().offset(k * 2);
         ptr::copy_nonoverlapping(d, result.offset(1), 2);
         sign as usize + 3
     } else if k >= 10 {
-        let d = DIGIT_TABLE.get_unchecked(k as usize * 2);
+        let d = DIGIT_TABLE.as_ptr().offset(k * 2);
         ptr::copy_nonoverlapping(d, result, 2);
         sign as usize + 2
     } else {
@@ -38,7 +38,7 @@ pub unsafe fn write_exponent2(mut k: isize, mut result: *mut u8) -> usize {
 
     debug_assert!(k < 100);
     if k >= 10 {
-        let d = DIGIT_TABLE.get_unchecked(k as usize * 2);
+        let d = DIGIT_TABLE.as_ptr().offset(k * 2);
         ptr::copy_nonoverlapping(d, result, 2);
         sign as usize + 2
     } else {

--- a/src/pretty/mantissa.rs
+++ b/src/pretty/mantissa.rs
@@ -15,10 +15,26 @@ pub unsafe fn write_mantissa_long(mut output: u64, mut result: *mut u8) {
         let c1 = (c / 100) << 1;
         let d0 = (d % 100) << 1;
         let d1 = (d / 100) << 1;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c0 as usize), result.offset(-2), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c1 as usize), result.offset(-4), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(d0 as usize), result.offset(-6), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(d1 as usize), result.offset(-8), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c0 as isize),
+            result.offset(-2),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c1 as isize),
+            result.offset(-4),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(d0 as isize),
+            result.offset(-6),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(d1 as isize),
+            result.offset(-8),
+            2,
+        );
         result = result.offset(-8);
     }
     write_mantissa(output as u32, result);
@@ -31,19 +47,35 @@ pub unsafe fn write_mantissa(mut output: u32, mut result: *mut u8) {
         output /= 10_000;
         let c0 = (c % 100) << 1;
         let c1 = (c / 100) << 1;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c0 as usize), result.offset(-2), 2);
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c1 as usize), result.offset(-4), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c0 as isize),
+            result.offset(-2),
+            2,
+        );
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c1 as isize),
+            result.offset(-4),
+            2,
+        );
         result = result.offset(-4);
     }
     if output >= 100 {
         let c = ((output % 100) << 1) as u32;
         output /= 100;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c as usize), result.offset(-2), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c as isize),
+            result.offset(-2),
+            2,
+        );
         result = result.offset(-2);
     }
     if output >= 10 {
         let c = (output << 1) as u32;
-        ptr::copy_nonoverlapping(DIGIT_TABLE.get_unchecked(c as usize), result.offset(-2), 2);
+        ptr::copy_nonoverlapping(
+            DIGIT_TABLE.as_ptr().offset(c as isize),
+            result.offset(-2),
+            2,
+        );
     } else {
         *result.offset(-1) = b'0' + output as u8;
     }


### PR DESCRIPTION
With MIRIFLAGS=-Zmiri-track-raw-pointers, miri detects a violation of
stacked borrows because slice::get_unchecked produces a pointer which only has
provenance over the single element at that index, but
copy_nonoverlapping was used to copy that element and the one after it.
The new implementation uses .as_ptr() which returns a pointer that has
provenance over the whole buffer.